### PR TITLE
Breaking page layout on "static" and "no_ember" pages

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -87,11 +87,11 @@
   }
 }
 
-.d-header {
+.d-header-branded {
     margin-top: 48px;
 }
 
-.docked .d-header {
+.docked .d-header-branded {
     margin-top: 0;
 }
 

--- a/common/header.html
+++ b/common/header.html
@@ -1,5 +1,18 @@
 <script type="text/discourse-plugin" version="0.8">
 
+  /**
+   *
+   * Activate widget in the CSS domain at runtime to hack
+   * the rendering problem on "static" and "no_ember" pages away.
+   *
+   * See also:
+   * https://meta.discourse.org/t/brand-header-theme-component-breaks-page-layout-on-static-and-no-ember-pages/106544/4
+   *
+  **/
+  $(document).ready(function() {
+    $('.d-header').addClass('d-header-branded');
+  });
+
   const { h } = require('virtual-dom');
   const { applyDecorators } = require('discourse/widgets/widget');
   const SiteHeaderComponent = require('discourse/components/site-header').default;


### PR DESCRIPTION
Hi there,

## Introduction
We ran into an issue that the [Brand header theme component breaks page layout on static and no_ember pages](https://meta.discourse.org/t/brand-header-theme-component-breaks-page-layout-on-static-and-no-ember-pages/106544) the other day. @vinothkannans knows about it already.

## Idea
The idea is to delay the visual activation of the widget by corresponding CSS rules to component startup time. By applying this workaround, we can at least assure that the page rendering on `static`  and `no_ember` pages is not completely broken anymore.

However, the banner header will then not display on these pages. So, while there's certainly room for improvement, this is the best we could make out of this.

## How does this work?
The patch works by encapsulating the visual activation through the CSS rules which earlier got applied barely to the `.d-header` class to corresponding rules now defined by the new `.d-header-branded` class.

This class will then get attached to the header element (found by searching for the original `.d-header` class) at component runtime, thus the widget will only appear when it is actually able to get initialized/executed.

Hope this helps.

With kind regards,
Andreas.

P.S.: This patch should still work even after [Bug: Almost void Discourse object instance will sneak through some safeguards](https://meta.discourse.org/t/almost-void-discourse-object-instance-will-sneak-through-some-safeguards/106553) will get fixed.
