### PR TITLE
add optional target parameter

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -81,7 +81,14 @@
       if (links) {
         return links.split("|").map(l => {
           const values = l.split(",");
-          return this.attach('link', { rawLabel: values[0], href: values[1] });
+          return this.attach('link', {
+              rawLabel: values[0].trim(),
+              href: values[1].trim(),
+              omitSpan: true,
+              attributes: {
+                target: (values[2] || '').trim()
+              }
+          });
         });
       } else {
         return [];
@@ -94,7 +101,14 @@
       if (icons) {
         return icons.split("|").map(l => {
           const values = l.split(",");
-          return this.attach('link', { icon: values[0], href: values[1] });
+          return this.attach('link', {
+              icon: values[0].trim(),
+              href: values[1].trim(),
+              omitSpan: true,
+              attributes: {
+                target: (values[2] || '').trim()
+              }
+          });
         });
       } else {
         return [];


### PR DESCRIPTION
Not sure if this is the best implementation but it works fine. I added the additional trim()s because with your current core you ended up with spaces in the url if people did `Name, url`

I added `omitSpan` because otherwise `target` won't work since the click will be on the `span` and not the `a`.