### PR TITLE
FIX: Dark mode and updated SCSS compiler compatibility

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,7 +1,4 @@
-@import "theme_variables";
-
 .b-header {
-
   .contents {
     margin: 8px 0;
   }
@@ -25,15 +22,16 @@
   .nav-pills {
     margin-bottom: 0;
     > li > a {
-      color: $secondary;
+      color: var(--secondary);
       line-height: 22px;
       &:hover {
-        color: $quaternary;
-        background-color: dark-light-diff($quaternary, $tertiary, -70%, 70%);
+        color: var(--quaternary);
+        background-color: var(quaternary-low);
       }
-      &.active > a, > a.active {
-        color: $secondary;
-        background-color: $quaternary;
+      &.active > a,
+      > a.active {
+        color: var(--secondary);
+        background-color: var(--quaternary);
       }
     }
   }
@@ -53,7 +51,7 @@
       float: left;
       list-style: none;
     }
-    a, [class^="fa fa-"] {
+    a {
       width: 28px;
       height: 28px;
       font-size: 16px;
@@ -62,7 +60,7 @@
       margin: 2px;
     }
     .rtl & {
-        margin: 0 5px 0 0;
+      margin: 0 5px 0 0;
       > li {
         float: right;
       }
@@ -71,8 +69,9 @@
 
   .panel > ul.icons {
     float: right;
-    a, [class^="fa fa-"] {
-      color: $secondary;
+    a,
+    .d-icon {
+      color: var(--secondary);
     }
     .rtl & {
       float: left;

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -1,8 +1,6 @@
-@import "theme_variables";
-
 .b-header {
   width: 100%;
-  background-color: $tertiary;
+  background-color: var(--tertiary);
   height: 48px;
   margin-bottom: 0;
 
@@ -10,10 +8,10 @@
     float: left;
     margin-right: 24px;
     a {
-      color: $secondary;
+      color: var(--secondary);
     }
     &:visited {
-      color: $secondary;
+      color: var(--secondary);
     }
     .rtl & {
       float: right;

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -1,12 +1,11 @@
 .b-header {
-
   .title {
     padding: 0.5em;
     a {
-      color: $tertiary;
+      color: var(--tertiary);
     }
     &:visited {
-      color: $tertiary;
+      color: var(--tertiary);
     }
   }
 
@@ -28,4 +27,6 @@
   }
 }
 
-.profiler-results { display: none ; }
+.profiler-results {
+  display: none;
+}


### PR DESCRIPTION
- `@import "theme_variables"` is no longer supported in core since https://github.com/discourse/discourse/commit/e8b82724fd303424f042b2b0d0b98a463676659d (and is not necessary, core already injects those variables)
- colors are now dark-mode-friendly