### PR TITLE
FEATURE: add plugin outlet setting

### DIFF
--- a/javascripts/discourse/initializers/initialize-brand-header.js
+++ b/javascripts/discourse/initializers/initialize-brand-header.js
@@ -14,7 +14,7 @@ export default {
     );
 
     withPluginApi("1.14.0", (api) => {
-      api.renderInOutlet("above-site-header", BrandHeaderContainer);
+      api.renderInOutlet(settings.plugin_outlet, BrandHeaderContainer);
     });
   },
 };

--- a/settings.yaml
+++ b/settings.yaml
@@ -24,3 +24,9 @@ custom_font_awesome_icons:
 show_bar_on_mobile:
   type: bool
   default: false
+plugin_outlet:
+  default: "above-site-header"
+  type: enum
+  choices:
+    - "above-site-header"
+    - "below-site-header"


### PR DESCRIPTION
This adds a setting to select the plugin outlet, allowing this component to appear below the site header if desired (default is appearing above the header). 


![Screenshot 2023-10-25 at 9 54 09 AM](https://github.com/discourse/discourse-brand-header/assets/1681963/d7788656-a9f2-4af3-b6fc-f4fef55a3638)
