### PR TITLE
FIX: Invalid validation key for string type

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -17,14 +17,14 @@ links:
         type: string
         required: true
         validations:
-          min: 1
-          max: 100
+          min_length: 1
+          max_length: 100
       url:
         type: string
         required: true
         validations:
-          min: 1
-          max: 2048
+          min_length: 1
+          max_length: 2048
           url: true
       target:
         type: enum
@@ -45,14 +45,14 @@ icons:
         type: string
         required: true
         validations:
-          min: 1
-          max: 100
+          min_length: 1
+          max_length: 100
       url:
         type: string
         required: true
         validations:
-          min: 1
-          max: 2048
+          min_length: 1
+          max_length: 2048
           url: true
       target:
         type: enum


### PR DESCRIPTION
For `type: string`, the validation keys for minimum and maximum length
should be `min_length` and `max_length`
