### PR TITLE
FIX: Client side error when `settings.icons` or `settings.links` is null

### DIFF
--- a/javascripts/discourse/components/brand-header-contents.gjs
+++ b/javascripts/discourse/components/brand-header-contents.gjs
@@ -23,11 +23,11 @@ export default class BrandHeaderContents extends Component {
   }
 
   get hasIcons() {
-    return settings.icons.length > 0;
+    return settings.icons && settings.icons.length > 0;
   }
 
   get hasLinks() {
-    return settings.links.length > 0;
+    return settings.links && settings.links.length > 0;
   }
 
   <template>


### PR DESCRIPTION
I'm not quite sure how `settings.icons` or `settings.links` can somehow
be `null` but we are seeing this problem in production so pushing out a
fix first.
