### PR TITLE
FIX: `links` and `icons` theme setting migrations to handle blank string

### DIFF
--- a/migrations/settings/0001-migrate-links-setting.js
+++ b/migrations/settings/0001-migrate-links-setting.js
@@ -1,7 +1,7 @@
 export default function migrate(settings) {
   const oldSetting = settings.get("links");
 
-  if (oldSetting) {
+  if (typeof oldSetting === "string") {
     const newLinks = [];
 
     oldSetting.split("|").forEach((link) => {

--- a/migrations/settings/0002-migrate-icons-setting.js
+++ b/migrations/settings/0002-migrate-icons-setting.js
@@ -1,7 +1,7 @@
 export default function migrate(settings) {
   const oldSetting = settings.get("icons");
 
-  if (oldSetting) {
+  if (typeof oldSetting === "string") {
     const newIcons = [];
 
     oldSetting.split("|").map((link) => {

--- a/test/unit/migrations/settings/0001-migrate-links-setting-test.js
+++ b/test/unit/migrations/settings/0001-migrate-links-setting-test.js
@@ -4,6 +4,22 @@ import migrate from "../../../../migrations/settings/0001-migrate-links-setting"
 module(
   "Brand Header | Unit | Migrations | Settings | 0001-migrate-links-setting",
   function () {
+    test("migrate when old setting is a blank string", function (assert) {
+      const settings = new Map(Object.entries({ links: "" }));
+      const result = migrate(settings);
+
+      const expectedResult = new Map(
+        Object.entries({
+          links: [],
+        })
+      );
+
+      assert.deepEqual(
+        Object.fromEntries(result.entries()),
+        Object.fromEntries(expectedResult.entries())
+      );
+    });
+
     test("migrate when old setting is of an invalid format", function (assert) {
       const settings = new Map(
         Object.entries({

--- a/test/unit/migrations/settings/0002-migrate-icons-setting-test.js
+++ b/test/unit/migrations/settings/0002-migrate-icons-setting-test.js
@@ -4,6 +4,22 @@ import migrate from "../../../../migrations/settings/0002-migrate-icons-setting"
 module(
   "Brand Header | Unit | Migrations | Settings | 0002-migrate-icons-setting",
   function () {
+    test("migrate when old setting is a blank string", function (assert) {
+      const settings = new Map(Object.entries({ icons: "" }));
+      const result = migrate(settings);
+
+      const expectedResult = new Map(
+        Object.entries({
+          icons: [],
+        })
+      );
+
+      assert.deepEqual(
+        Object.fromEntries(result.entries()),
+        Object.fromEntries(expectedResult.entries())
+      );
+    });
+
     test("migrate when old setting value is of an invalid format", function (assert) {
       const settings = new Map(
         Object.entries({


### PR DESCRIPTION
If the old theme setting value is set to a blank string, we will end up
not migrating it and thus cause an error to be raised.
