### PR TITLE
DEV: Remove unused widget shim

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,3 +1,4 @@
+< 3.5.0.beta9-dev: 6fd676ea4e9cd7305d03df93bd6ce99961e4ff17
 < 3.5.0.beta5-dev: b2f4dd70a8b6f7ea885082b083c9d33d767cce9a
 < 3.5.0.beta1-dev: 3402e1c8182fa2d5fed33c8bf4eaea131af4124e
 < 3.4.0.beta1-dev: 9e7c22402b8af821e44d1213bebb4e6e75245e1d

--- a/javascripts/discourse/initializers/initialize-brand-header.js
+++ b/javascripts/discourse/initializers/initialize-brand-header.js
@@ -1,19 +1,11 @@
-import { hbs } from "ember-cli-htmlbars";
 import { withPluginApi } from "discourse/lib/plugin-api";
-import { registerWidgetShim } from "discourse/widgets/render-glimmer";
 import BrandHeaderContainer from "../components/brand-header-container";
 
 export default {
   name: "brand-header",
 
   initialize() {
-    registerWidgetShim(
-      "brand-header-contents",
-      "div.brand-header-contents",
-      hbs`<BrandHeaderContents />`
-    );
-
-    withPluginApi("1.14.0", (api) => {
+    withPluginApi((api) => {
       api.renderInOutlet(settings.plugin_outlet, BrandHeaderContainer);
     });
   },


### PR DESCRIPTION
Remove unused widget shim from `initialize-brand-header`.

Adjust compatibility for `< 3.5.0.beta9-dev`.